### PR TITLE
Fix HTML escaping

### DIFF
--- a/grupy_sanca_agenda_bot/utils.py
+++ b/grupy_sanca_agenda_bot/utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import pytz
 from telegram import Update
 from telegram.ext import Application
-from telegram.helpers import escape_markdown
 
 from grupy_sanca_agenda_bot.constants import PeriodEnum
 from grupy_sanca_agenda_bot.settings import settings


### PR DESCRIPTION
The HTML tags are already being stripped in the `OpenEventExtractor`.
Using `escape_markdown` in `send_message()` was breaking the `Markdown` formatting in the scheduled messages.